### PR TITLE
Remove some Hello World e2e tests

### DIFF
--- a/tests/e2e/specs/block-editor/blocks/hello-world.spec.js
+++ b/tests/e2e/specs/block-editor/blocks/hello-world.spec.js
@@ -1,16 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	createNewPost,
-	insertBlock,
-	publishPost,
-} from '@wordpress/e2e-test-utils';
-
-/**
- * WordPress dependencies
- */
-import { clickButton } from '../../../utils';
+import { createNewPost, insertBlock } from '@wordpress/e2e-test-utils';
 
 describe( 'blocks: material/hello-world', () => {
 	beforeEach( async () => {
@@ -24,45 +15,5 @@ describe( 'blocks: material/hello-world', () => {
 		expect(
 			await page.$( '[data-type="material/hello-world"]' )
 		).not.toBeNull();
-	} );
-
-	it( 'should have the correct edit text', async () => {
-		await insertBlock( 'Hello World' );
-
-		const content = await page.$eval(
-			'[data-type="material/hello-world"] h2',
-			node => node.textContent
-		);
-		expect( content ).toStrictEqual( 'Hello Editor' );
-	} );
-
-	it( 'should have the correct save text', async () => {
-		await insertBlock( 'Hello World' );
-
-		await page.waitForSelector( '[data-type="material/hello-world"] h2' );
-		await publishPost();
-
-		await page.waitForSelector(
-			'.post-publish-panel__postpublish-post-address input'
-		);
-
-		const url = await page.$eval(
-			'.post-publish-panel__postpublish-post-address input',
-			el => el.value
-		);
-		const edit = await page.url();
-
-		await page.goto( url );
-		await page.waitForSelector( '.wp-block-material-hello-world' );
-		const content = await page.$eval(
-			'.wp-block-material-hello-world',
-			node => node.textContent
-		);
-
-		await page.goto( edit );
-		await page.waitForSelector( '.editor-post-trash' );
-		await clickButton( 'Move to Trash' );
-
-		expect( content ).toStrictEqual( 'Hello Website' );
 	} );
 } );


### PR DESCRIPTION
## Summary

Removes some of the e2e test for the Hello World block to stabilize the tests.
<!-- Please reference the issue this PR addresses. -->
Fixes #

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/xwp/material-theme-builder-wp/issues) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/xwp/material-theme-builder-wp/contributing.md#scripts).
- [x] My code follows the [Contributing Guidelines](https://github.com/xwp/material-theme-builder-wp/contributing.md) (updates are often made to the guidelines, check it out periodically).
