### PR TITLE
Update tested upto to 5.7 and bump version

### DIFF
--- a/material-design.php
+++ b/material-design.php
@@ -3,7 +3,7 @@
  * Plugin Name: Material Design
  * Plugin URI: https://github.com/xwp/material-design-wp-plugin
  * Description: The official Material Design plugin for WordPress. Customize your site’s navigation, colors, typography, and shapes, use Material Components, and choose from over 1,000 Google Fonts and Material Design icons. From the team behind Google’s open-source design system.
- * Version: 0.1.1
+ * Version: 0.1.2
  * Author:  Material Design
  * Author URI: http://material.io
  * License: Apache License, Version 2.0

--- a/readme.md
+++ b/readme.md
@@ -6,8 +6,8 @@ The official Material Design plugin for WordPress. Customize your site’s navig
 
 **Contributors:** [google](https://profiles.wordpress.org/google), [materialdesign](https://profiles.wordpress.org/materialdesign), [xwp](https://profiles.wordpress.org/xwp)  
 **Requires at least:** 5.2  
-**Tested up to:** 5.6  
-**Stable tag:** 0.1.1  
+**Tested up to:** 5.7  
+**Stable tag:** 0.1.2  
 **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)  
 
 [![Build Status](https://travis-ci.com/xwp/material-design-wp-plugin.svg?branch=develop)](https://travis-ci.com/xwp/material-design-wp-plugin) [![Coverage Status](https://coveralls.io/repos/xwp/material-design-wp-plugin/badge.svg?branch=develop)](https://coveralls.io/github/xwp/material-design-wp-plugin) [![Built with Grunt](https://gruntjs.com/cdn/builtwith.svg)](http://gruntjs.com) 

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Material Design for WordPress ===
 Contributors: google, materialdesign, xwp
 Requires at least: 5.2
-Tested up to: 5.6
-Stable tag: 0.1.1
+Tested up to: 5.7
+Stable tag: 0.1.2
 License: Apache License, Version 2.0
 License URI: https://www.apache.org/licenses/LICENSE-2.0
 


### PR DESCRIPTION
## Changelog

* Fix assets SVN deploy issue, built assets are not deployed to SVN when using the `grunt deploy` command.
* Bump tested up to WordPress 5.7

## Props
Thanks to the many contributors who made this release possible through work on development, design, testing, project management, and more:

@ravichdev, @derekherman 

---

- [x] Update changelog
- [x] Add contributors
- [ ] Merge & tag a release